### PR TITLE
config🔧:  升级依赖三方包的 react-scripts 版本为 4.0.3

### DIFF
--- a/examples/simple-BI/package.json
+++ b/examples/simple-BI/package.json
@@ -23,7 +23,7 @@
     "react-redux": "^7.2.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.4.0",
+    "react-scripts": "^4.0.3",
     "redux": "^4.0.0",
     "redux-saga": "^0.16.0",
     "reselect": "^3.0.0",


### PR DESCRIPTION
https://github.com/ProtoTeam/redux-with-domain/issues/3